### PR TITLE
feat: always log `error` and `warn`

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,7 +13,7 @@ const levels = ['error', 'warn', 'info', 'debug', 'trace', 'log'];
 
 levels.forEach((level) => {
   logger[level] = (...args) => {
-    if (process.env.AWS_XRAY_DEBUG_MODE) {
+    if (process.env.AWS_XRAY_DEBUG_MODE || ['error', 'warn'].includes(level)) {
       /* eslint-disable no-console */
       console[level](`${getTimestamp()} [${level.toUpperCase()}]`, ...args);
       /* eslint-enable no-console */


### PR DESCRIPTION
Since it's changing default behavior we're going to tag this one as a breaking change.